### PR TITLE
feat: persistent IPC token with Settings UI

### DIFF
--- a/Calyx/Features/Settings/SettingsWindowController.swift
+++ b/Calyx/Features/Settings/SettingsWindowController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import OSLog
+import Security
 
 private let logger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.calyx.terminal",
@@ -19,10 +20,12 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let hexField = NSTextField()
     private var lastLoadedPreset: String = "original"
     private var lastLoadedCustomHex: String = ThemeColorPreset.defaultCustomHex
+    private var ipcRandomCheckbox: NSButton?
+    private var ipcTokenField: NSTextField?
 
     private init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 550),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 650),
             styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false
@@ -177,6 +180,56 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
         managedKeysList.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
         managedKeysList.textColor = .tertiaryLabelColor
         root.addArrangedSubview(managedKeysList)
+
+        // --- IPC Section ---
+        let ipcDivider = NSBox()
+        ipcDivider.boxType = .separator
+        ipcDivider.translatesAutoresizingMaskIntoConstraints = false
+        ipcDivider.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        root.addArrangedSubview(ipcDivider)
+
+        let ipcTitle = NSTextField(labelWithString: "AI Agent IPC")
+        ipcTitle.font = .systemFont(ofSize: 20, weight: .semibold)
+        root.addArrangedSubview(ipcTitle)
+
+        let ipcSubtitle = NSTextField(wrappingLabelWithString: "Controls how AI agents authenticate to the Calyx MCP server.")
+        ipcSubtitle.textColor = .secondaryLabelColor
+        ipcSubtitle.font = .systemFont(ofSize: 13)
+        root.addArrangedSubview(ipcSubtitle)
+
+        // Random token checkbox
+        let randomCheckbox = NSButton(
+            checkboxWithTitle: "Generate random token on each enable",
+            target: self,
+            action: #selector(ipcRandomTokenDidChange(_:))
+        )
+        let randomize = UserDefaults.standard.object(forKey: "ipcRandomToken") as? Bool ?? true
+        randomCheckbox.state = randomize ? .on : .off
+        self.ipcRandomCheckbox = randomCheckbox
+        root.addArrangedSubview(randomCheckbox)
+
+        // Token display row
+        let tokenField = NSTextField(string: UserDefaults.standard.string(forKey: "ipcToken") ?? "")
+        tokenField.isEditable = false
+        tokenField.isSelectable = true
+        tokenField.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        tokenField.textColor = .secondaryLabelColor
+        tokenField.placeholderString = "(no token yet)"
+        tokenField.lineBreakMode = .byTruncatingMiddle
+        tokenField.widthAnchor.constraint(greaterThanOrEqualToConstant: 300).isActive = true
+        self.ipcTokenField = tokenField
+
+        let copyButton = NSButton(title: "Copy", target: self, action: #selector(copyIPCToken(_:)))
+        copyButton.bezelStyle = .rounded
+
+        let regenButton = NSButton(title: "Regenerate", target: self, action: #selector(regenerateIPCToken(_:)))
+        regenButton.bezelStyle = .rounded
+
+        let tokenRow = NSStackView(views: [tokenField, copyButton, regenButton])
+        tokenRow.orientation = .horizontal
+        tokenRow.spacing = 8
+        tokenRow.alignment = .centerY
+        root.addArrangedSubview(row(label: "Token", control: tokenRow))
 
         loadPresetIntoUI()
     }
@@ -387,6 +440,11 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
         }
         hexField.textColor = .labelColor
 
+        // Refresh IPC fields
+        let ipcRandom = UserDefaults.standard.object(forKey: "ipcRandomToken") as? Bool ?? true
+        ipcRandomCheckbox?.state = ipcRandom ? .on : .off
+        ipcTokenField?.stringValue = UserDefaults.standard.string(forKey: "ipcToken") ?? ""
+
         snapshotCurrentAsLoaded()
         refreshSaveButtonState()
     }
@@ -458,5 +516,26 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
             GhosttyAppController.shared.reloadConfig()
             return false
         }
+    }
+
+    // MARK: - IPC Token Actions
+
+    @objc private func ipcRandomTokenDidChange(_ sender: NSButton) {
+        UserDefaults.standard.set(sender.state == .on, forKey: "ipcRandomToken")
+    }
+
+    @objc private func copyIPCToken(_ sender: Any?) {
+        let token = UserDefaults.standard.string(forKey: "ipcToken") ?? ""
+        guard !token.isEmpty else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(token, forType: .string)
+    }
+
+    @objc private func regenerateIPCToken(_ sender: Any?) {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else { return }
+        let token = bytes.map { String(format: "%02x", $0) }.joined()
+        UserDefaults.standard.set(token, forKey: "ipcToken")
+        ipcTokenField?.stringValue = token
     }
 }

--- a/Calyx/Views/MainWindow/CalyxWindowController.swift
+++ b/Calyx/Views/MainWindow/CalyxWindowController.swift
@@ -1774,14 +1774,25 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
 
     private func enableIPC() {
         do {
-            // Generate token: 32 random bytes as hex
-            var bytes = [UInt8](repeating: 0, count: 32)
-            let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-            guard status == errSecSuccess else {
-                showIPCAlert(title: "IPC Error", message: "Failed to generate secure token.")
-                return
+            let ud = UserDefaults.standard
+            let randomize = ud.object(forKey: "ipcRandomToken") as? Bool ?? true
+            let savedToken = ud.string(forKey: "ipcToken") ?? ""
+            let token: String
+
+            if !randomize && !savedToken.isEmpty {
+                // Reuse the persisted token
+                token = savedToken
+            } else {
+                // Generate token: 32 random bytes as hex
+                var bytes = [UInt8](repeating: 0, count: 32)
+                let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+                guard status == errSecSuccess else {
+                    showIPCAlert(title: "IPC Error", message: "Failed to generate secure token.")
+                    return
+                }
+                token = bytes.map { String(format: "%02x", $0) }.joined()
+                ud.set(token, forKey: "ipcToken")
             }
-            let token = bytes.map { String(format: "%02x", $0) }.joined()
 
             // Start server first to get the port
             try CalyxMCPServer.shared.start(token: token)


### PR DESCRIPTION
## Summary

- `enableIPC()` now reuses a saved bearer token instead of generating a fresh one every time (when configured)
- New "AI Agent IPC" section in Settings window for token management
- Minimal change: only 2 files modified, no new dependencies, stored in UserDefaults

## Changes

### `CalyxWindowController.swift`
- `enableIPC()` checks `ipcRandomToken` (UserDefaults bool, default `true`)
- When `false` and a saved token exists: reuses the persisted `ipcToken`
- When `true` or no token saved: generates a new random token and persists it

### `SettingsWindowController.swift`
- New "AI Agent IPC" section at the bottom of the Settings window:
  - **Checkbox**: "Generate random token on each enable" — toggles between random and persistent mode
  - **Token field**: read-only, monospaced, shows current token
  - **Copy button**: copies token to clipboard
  - **Regenerate button**: generates a new 32-byte random hex token
- Window height increased from 550 to 650 to accommodate the new section

## UserDefaults keys added
- `ipcRandomToken` (Bool, default `true`) — whether to generate a new token each time
- `ipcToken` (String) — the persisted bearer token

## Testing
- Build: **SUCCEEDED** (Xcode 26.3)
- Tests: **273 passed**, 0 failures