### PR TITLE
[codex] Fix unfocused window dimming

### DIFF
--- a/Calyx/App/AppDelegate.swift
+++ b/Calyx/App/AppDelegate.swift
@@ -87,7 +87,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Already confirmed (from windowShouldClose on last-window close path)
         if isTerminationConfirmed {
-            isTerminationConfirmed = false
             markAllControllersClosingForShutdown()
             return .terminateNow
         }
@@ -233,6 +232,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !windowControllers.isEmpty {
             requestSave()
         } else if quickTerminalController == nil {
+            // The last managed window has already passed windowShouldClose.
+            // Avoid a second app-level confirmation after the window is gone.
+            isTerminationConfirmed = true
             NSApp.terminate(nil)
         }
     }
@@ -242,10 +244,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Returns true if the app should proceed with quit, false if user cancelled.
-    func confirmQuitIfNeeded() -> Bool {
+    func confirmQuitIfNeeded(includeCloseConfirmation: Bool = true) -> Bool {
+        let needsProcessConfirmation: Bool = {
+            guard let app = GhosttyAppController.shared.app else { return false }
+            return ghostty_app_needs_confirm_quit(app)
+        }()
+
+        if includeCloseConfirmation && CloseConfirmationSettings.isEnabled && !needsProcessConfirmation {
+            let alert = NSAlert()
+            alert.messageText = "Quit Calyx?"
+            alert.informativeText = "This will close all Calyx windows and tabs."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "Quit")
+            alert.addButton(withTitle: "Cancel")
+
+            if alert.runModal() == .alertSecondButtonReturn {
+                return false
+            }
+        }
+
         // 1. Check for running processes
-        if let app = GhosttyAppController.shared.app,
-           ghostty_app_needs_confirm_quit(app) {
+        if needsProcessConfirmation {
             let alert = NSAlert()
             alert.messageText = "Quit Calyx?"
             alert.informativeText = "A process is still running. Do you want to quit?"

--- a/Calyx/Features/CommandPalette/CommandPaletteView.swift
+++ b/Calyx/Features/CommandPalette/CommandPaletteView.swift
@@ -2,7 +2,7 @@
 // Calyx
 //
 // Overlay panel at top of window for command palette UI.
-// Glass styling is applied on the SwiftUI side via .glassEffect(.regular).
+// Glass styling is applied by the SwiftUI host.
 
 import AppKit
 import os

--- a/Calyx/Features/QuickTerminal/QuickTerminalContentView.swift
+++ b/Calyx/Features/QuickTerminal/QuickTerminalContentView.swift
@@ -27,8 +27,9 @@ struct QuickTerminalContentView: View {
             )
             .padding(.top, -1)
             .padding(.leading, 8)
-            .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+            .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
         }
+        .environment(\.controlActiveState, .key)
         .background {
             if !reduceTransparency {
                 Rectangle()

--- a/Calyx/Features/Settings/CloseConfirmationSettings.swift
+++ b/Calyx/Features/Settings/CloseConfirmationSettings.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum CloseConfirmationSettings {
+    static let key = "confirmBeforeClosingTabsAndWindows"
+    static let defaultValue = true
+
+    static var isEnabled: Bool {
+        get {
+            if ProcessInfo.processInfo.arguments.contains("--uitesting") {
+                return false
+            }
+            return UserDefaults.standard.object(forKey: key) as? Bool ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}

--- a/Calyx/Features/Settings/SettingsWindowController.swift
+++ b/Calyx/Features/Settings/SettingsWindowController.swift
@@ -17,12 +17,13 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
     private let presetPopup = NSPopUpButton(frame: .zero, pullsDown: false)
     private let colorWell = NSColorWell()
     private let hexField = NSTextField()
+    private let closeConfirmationSwitch = NSSwitch()
     private var lastLoadedPreset: String = "original"
     private var lastLoadedCustomHex: String = ThemeColorPreset.defaultCustomHex
 
     private init() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 550),
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 620),
             styleMask: [.titled, .closable, .resizable],
             backing: .buffered,
             defer: false
@@ -166,6 +167,22 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
         smoothScrollSwitch.target = self
         smoothScrollSwitch.action = #selector(smoothScrollDidChange(_:))
         root.addArrangedSubview(row(label: "Smooth Scrolling", control: smoothScrollSwitch))
+
+        // --- Confirmations Section ---
+        let confirmationDivider = NSBox()
+        confirmationDivider.boxType = .separator
+        confirmationDivider.translatesAutoresizingMaskIntoConstraints = false
+        confirmationDivider.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        root.addArrangedSubview(confirmationDivider)
+
+        let confirmationTitle = NSTextField(labelWithString: "Confirmations")
+        confirmationTitle.font = .systemFont(ofSize: 20, weight: .semibold)
+        root.addArrangedSubview(confirmationTitle)
+
+        closeConfirmationSwitch.state = CloseConfirmationSettings.isEnabled ? .on : .off
+        closeConfirmationSwitch.target = self
+        closeConfirmationSwitch.action = #selector(closeConfirmationDidChange(_:))
+        root.addArrangedSubview(row(label: "Ask before closing tabs and windows", control: closeConfirmationSwitch))
 
         // Divider before config info section
         let configDivider = NSBox()
@@ -311,6 +328,10 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
         }
     }
 
+    @objc private func closeConfirmationDidChange(_ sender: NSSwitch) {
+        CloseConfirmationSettings.isEnabled = sender.state == .on
+    }
+
     @objc private func presetDidChange(_ sender: Any?) {
         let index = presetPopup.indexOfSelectedItem
         let presets = ThemeColorPreset.allCases.filter { $0 != .custom }
@@ -395,6 +416,7 @@ class SettingsWindowController: NSWindowController, NSWindowDelegate {
         let opacity = UserDefaults.standard.object(forKey: "terminalGlassOpacity") as? Double ?? 0.7
         opacitySlider.doubleValue = max(0.0, min(1.0, opacity))
         updateOpacityLabel()
+        closeConfirmationSwitch.state = CloseConfirmationSettings.isEnabled ? .on : .off
 
         // Load theme color state
         let preset = UserDefaults.standard.string(forKey: "themeColorPreset") ?? "original"

--- a/Calyx/Views/Browser/BrowserContainerView.swift
+++ b/Calyx/Views/Browser/BrowserContainerView.swift
@@ -55,7 +55,7 @@ private struct BrowserToolbarView: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-        .glassEffect(.regular, in: .rect(cornerRadius: 0))
+        .stableGlassPanel()
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.Browser.toolbar)
     }

--- a/Calyx/Views/Glass/FloatingGlassModifier.swift
+++ b/Calyx/Views/Glass/FloatingGlassModifier.swift
@@ -69,7 +69,6 @@ struct TabChromeModifier: ViewModifier {
     let isActive: Bool
     let cornerRadius: CGFloat
     let reduceTransparency: Bool
-    @Environment(\.controlActiveState) private var controlActiveState
 
     func body(content: Content) -> some View {
         if reduceTransparency {
@@ -84,10 +83,47 @@ struct TabChromeModifier: ViewModifier {
                         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                             .fill(Color.black.opacity(0.2))
                     )
-                    .opacity(controlActiveState == .key ? 1.0 : 0.5)
             } else {
                 content
-                    .opacity(controlActiveState == .key ? 1.0 : 0.5)
+            }
+        }
+    }
+}
+
+extension View {
+    func stableGlassTint(_ tint: Color, cornerRadius: CGFloat = 0) -> some View {
+        modifier(StableGlassTintModifier(tint: tint, cornerRadius: cornerRadius))
+    }
+
+    func stableGlassPanel(cornerRadius: CGFloat = 0) -> some View {
+        modifier(StableGlassTintModifier(tint: Color.black.opacity(0.72), cornerRadius: cornerRadius))
+    }
+}
+
+private struct StableGlassTintModifier: ViewModifier {
+    let tint: Color
+    let cornerRadius: CGFloat
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if cornerRadius > 0 {
+            content.background {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(tint)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .fill(Color.black.opacity(0.10))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .stroke(Color.white.opacity(0.18), lineWidth: 1)
+                    )
+            }
+        } else {
+            content.background {
+                Rectangle()
+                    .fill(tint)
+                    .overlay(Color.black.opacity(0.10))
             }
         }
     }

--- a/Calyx/Views/MainWindow/CalyxWindowController.swift
+++ b/Calyx/Views/MainWindow/CalyxWindowController.swift
@@ -31,6 +31,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
     private var reviewStores: [UUID: DiffReviewStore] = [:]
     private var clipboardConfirmationController: ClipboardConfirmationController?
     private var composeOverlayTargetSurfaceID: UUID?
+    private var skipNextWindowCloseConfirmation = false
 
     // MARK: - Computed Properties
 
@@ -618,6 +619,8 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
         }) else { return }
         guard let tab = group.tabs.first(where: { $0.id == tabID }) else { return }
 
+        guard confirmCloseTabIfNeeded(tab) else { return }
+
         closingTabIDs.insert(tabID)
 
         // Quit confirmation: if this is the last tab in the last group, closing it
@@ -626,7 +629,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
             if let appDelegate = NSApp.delegate as? AppDelegate,
                appDelegate.closingWouldTerminate(self),
                !appDelegate.isTerminationConfirmed {
-                if !appDelegate.confirmQuitIfNeeded() {
+                if !appDelegate.confirmQuitIfNeeded(includeCloseConfirmation: false) {
                     closingTabIDs.remove(tabID)
                     return
                 }
@@ -671,6 +674,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
                appDelegate.closingWouldTerminate(self) {
                 appDelegate.isTerminationConfirmed = true
             }
+            skipNextWindowCloseConfirmation = true
             window?.close()
         }
 
@@ -752,6 +756,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
 
     private func closeActiveGroup() {
         guard let group = windowSession.activeGroup else { return }
+        guard confirmCloseGroupIfNeeded(group) else { return }
 
         // Mark all tabs as closing to prevent notification handler from double-deleting
         let tabIDs = group.tabs.map { $0.id }
@@ -765,7 +770,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
             if let appDelegate = NSApp.delegate as? AppDelegate,
                appDelegate.closingWouldTerminate(self),
                !appDelegate.isTerminationConfirmed {
-                if !appDelegate.confirmQuitIfNeeded() {
+                if !appDelegate.confirmQuitIfNeeded(includeCloseConfirmation: false) {
                     for tabID in tabIDs {
                         closingTabIDs.remove(tabID)
                     }
@@ -811,6 +816,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
                appDelegate.closingWouldTerminate(self) {
                 appDelegate.isTerminationConfirmed = true
             }
+            skipNextWindowCloseConfirmation = true
             window?.close()
             requestSave()
         }
@@ -818,6 +824,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
 
     private func closeAllTabsInGroup(id groupID: UUID) {
         guard let group = windowSession.groups.first(where: { $0.id == groupID }) else { return }
+        guard confirmCloseGroupIfNeeded(group) else { return }
 
         let wasActiveGroup = (groupID == windowSession.activeGroupID)
         let tabIDs = group.tabs.map { $0.id }
@@ -831,7 +838,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
             if let appDelegate = NSApp.delegate as? AppDelegate,
                appDelegate.closingWouldTerminate(self),
                !appDelegate.isTerminationConfirmed {
-                if !appDelegate.confirmQuitIfNeeded() {
+                if !appDelegate.confirmQuitIfNeeded(includeCloseConfirmation: false) {
                     for tabID in tabIDs {
                         closingTabIDs.remove(tabID)
                     }
@@ -876,6 +883,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
                appDelegate.closingWouldTerminate(self) {
                 appDelegate.isTerminationConfirmed = true
             }
+            skipNextWindowCloseConfirmation = true
             window?.close()
             requestSave()
         }
@@ -1535,6 +1543,54 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
         return nil
     }
 
+    private func confirmCloseTabIfNeeded(_ tab: Tab) -> Bool {
+        guard CloseConfirmationSettings.isEnabled else { return true }
+
+        let title = displayTitle(for: tab)
+        let alert = NSAlert()
+        alert.messageText = "Close Tab?"
+        alert.informativeText = "Close \"\(title)\"?"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Close Tab")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func confirmCloseGroupIfNeeded(_ group: TabGroup) -> Bool {
+        guard CloseConfirmationSettings.isEnabled else { return true }
+
+        let tabCount = group.tabs.count
+        let alert = NSAlert()
+        alert.messageText = tabCount == 1 ? "Close Group?" : "Close Group and Tabs?"
+        alert.informativeText = tabCount == 1
+            ? "Close \"\(group.name)\"?"
+            : "Close \"\(group.name)\" and its \(tabCount) tabs?"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: tabCount == 1 ? "Close Group" : "Close Group and Tabs")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func confirmCloseWindowIfNeeded() -> Bool {
+        guard CloseConfirmationSettings.isEnabled else { return true }
+
+        let tabCount = windowSession.groups.reduce(0) { $0 + $1.tabs.count }
+        let alert = NSAlert()
+        alert.messageText = "Close Window?"
+        alert.informativeText = tabCount == 1
+            ? "This will close 1 tab in this window."
+            : "This will close \(tabCount) tabs in this window."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Close Window")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+
+    private func displayTitle(for tab: Tab) -> String {
+        let title = (tab.titleOverride ?? tab.title).trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? "Untitled" : title
+    }
+
     private var focusedController: GhosttySurfaceController? {
         guard let tab = activeTab,
               let focusedID = tab.splitTree.focusedLeafID else { return nil }
@@ -1571,6 +1627,16 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if isClosingForShutdown {
+            return true
+        }
+
+        if skipNextWindowCloseConfirmation {
+            skipNextWindowCloseConfirmation = false
+        } else if !confirmCloseWindowIfNeeded() {
+            return false
+        }
+
         guard let appDelegate = NSApp.delegate as? AppDelegate,
               appDelegate.closingWouldTerminate(self) else {
             return true
@@ -1583,7 +1649,7 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
         }
 
         // Last-window close via X button: run confirmations
-        if !appDelegate.confirmQuitIfNeeded() {
+        if !appDelegate.confirmQuitIfNeeded(includeCloseConfirmation: false) {
             return false
         }
 

--- a/Calyx/Views/MainWindow/MainContentView.swift
+++ b/Calyx/Views/MainWindow/MainContentView.swift
@@ -171,7 +171,7 @@ struct MainContentView: View {
                                     }
                                 }
                             }
-                            .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                            .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
                             .accessibilityIdentifier(AccessibilityID.Diff.container)
                         } else if let browserController = activeBrowserController {
                             BrowserContainerView(controller: browserController)
@@ -183,7 +183,7 @@ struct MainContentView: View {
                                     glassOpacity: glassOpacity
                                 )
                                 .padding(.top, -1)
-                                .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                                .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
                                 .onDrop(of: [.fileURL], delegate: TerminalDropDelegate(splitContainerView: splitContainerView))
                                 .layoutPriority(1)
                                 .overlay(alignment: .topTrailing) {
@@ -205,7 +205,7 @@ struct MainContentView: View {
                                         )
                                         .frame(height: windowSession.composeOverlayHeight)
                                     }
-                                    .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                                    .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
                                 }
                             }
                         }
@@ -221,7 +221,7 @@ struct MainContentView: View {
                                 onDismiss: onDismissCommandPalette
                             )
                             .frame(width: 500, height: 340)
-                            .glassEffect(.regular, in: .rect(cornerRadius: 12))
+                            .stableGlassPanel(cornerRadius: 12)
 
                             Spacer()
                         }
@@ -231,9 +231,24 @@ struct MainContentView: View {
             }
             .overlay(alignment: .top) {
                 GeometryReader { geo in
-                    Color.white.opacity(0.001)
-                        .frame(height: geo.safeAreaInsets.top + 1)
-                        .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                    let titlebarHeight = max(geo.safeAreaInsets.top, 28)
+                    Rectangle()
+                        .fill(
+                            reduceTransparency
+                                ? Color(nsColor: .windowBackgroundColor)
+                                : Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))
+                        )
+                        .overlay {
+                            if !reduceTransparency {
+                                Color.black.opacity(0.10)
+                            }
+                        }
+                        .overlay(alignment: .bottom) {
+                            Rectangle()
+                                .fill(GlassTheme.specularStroke.opacity(0.28))
+                                .frame(height: 1)
+                        }
+                        .frame(height: titlebarHeight + 1)
                         .offset(y: -geo.safeAreaInsets.top)
                 }
                 .allowsHitTesting(false)
@@ -264,6 +279,7 @@ struct MainContentView: View {
                 }
             }
         }
+        .environment(\.controlActiveState, .key)
     }
 }
 

--- a/Calyx/Views/Sidebar/SidebarContentView.swift
+++ b/Calyx/Views/Sidebar/SidebarContentView.swift
@@ -111,7 +111,6 @@ struct SidebarContentView: View {
 
 private struct GlassButtonModifier: ViewModifier {
     let reduceTransparency: Bool
-    @Environment(\.controlActiveState) private var controlActiveState
 
     func body(content: Content) -> some View {
         if reduceTransparency {
@@ -123,7 +122,6 @@ private struct GlassButtonModifier: ViewModifier {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .fill(Color.black.opacity(0.2))
                 )
-                .opacity(controlActiveState == .key ? 1.0 : 0.5)
         }
     }
 }
@@ -153,20 +151,11 @@ private struct SidebarBackgroundModifier: ViewModifier {
             content.background(Color(nsColor: .controlBackgroundColor).ignoresSafeArea(.all, edges: .top))
         } else {
             content
-                .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
                 .overlay(alignment: .trailing) {
                     Rectangle()
                         .fill(GlassTheme.specularStroke.opacity(0.30))
                         .frame(width: 1)
-                }
-                .overlay(alignment: .topLeading) {
-                    LinearGradient(
-                        colors: [Color.white.opacity(0.20), Color.clear],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .frame(height: 32)
-                    .allowsHitTesting(false)
                 }
                 .environment(\.colorScheme, chromeScheme)
                 .foregroundStyle(themePreset == "ghostty"
@@ -410,23 +399,7 @@ private struct GroupHeaderBackgroundModifier: ViewModifier {
                 )
         } else if isActiveGroup {
             content
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(
-                            LinearGradient(
-                                colors: [
-                                    groupColor.color.opacity(0.16),
-                                    Color.gray.opacity(0.10),
-                                ],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
-                            )
-                        )
-                )
-                .glassEffect(
-                    .clear.tint(groupColor.color.opacity(0.12)).interactive(),
-                    in: .rect(cornerRadius: 12)
-                )
+                .stableGlassTint(groupColor.color.opacity(0.12), cornerRadius: 12)
                 .overlay {
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .stroke(Color.white.opacity(0.22), lineWidth: 1)

--- a/Calyx/Views/Split/SplitDividerView.swift
+++ b/Calyx/Views/Split/SplitDividerView.swift
@@ -120,10 +120,7 @@ private struct SplitDividerGlassStrip: View {
 
     var body: some View {
         Color.clear
-            .glassEffect(
-                .clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))),
-                in: .rect
-            )
+            .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
             .opacity(0.5)
             .allowsHitTesting(false)
     }

--- a/Calyx/Views/TabBar/TabBarContentView.swift
+++ b/Calyx/Views/TabBar/TabBarContentView.swift
@@ -326,22 +326,11 @@ private struct TabBarBackgroundModifier: ViewModifier {
             content.background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea(.all, edges: .top))
         } else {
             content
-                .glassEffect(.clear.tint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity))), in: .rect)
+                .stableGlassTint(Color(nsColor: GlassTheme.chromeTint(for: themeColor, glassOpacity: glassOpacity)))
                 .overlay(alignment: .bottom) {
                     Rectangle()
                         .fill(GlassTheme.specularStroke.opacity(0.28))
                         .frame(height: 1)
-                }
-                .overlay(alignment: .top) {
-                    Rectangle()
-                        .fill(
-                            LinearGradient(
-                                colors: [Color.white.opacity(0.20), Color.clear],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                        )
-                        .frame(height: 18)
                 }
                 .environment(\.colorScheme, chromeScheme)
                 .foregroundStyle(themePreset == "ghostty"


### PR DESCRIPTION
## Summary

- Replace SwiftUI native `glassEffect` usage on persistent chrome surfaces with app-owned stable tint backgrounds so the window no longer fades when inactive.
- Remove the hardcoded inactive opacity reduction from tab/sidebar chrome controls.
- Restore an opaque titlebar band and remove the extra top gradient highlights from the tabbar and sidebar.

## Why

Calyx currently dims key chrome surfaces when the app loses focus. This makes the whole window look washed out in the background and is tracked in #22.

## Impact

The main window, quick terminal, tabbar, sidebar, split divider, browser toolbar, command palette, and compose/diff/terminal surfaces keep a stable visual appearance whether Calyx is focused or unfocused. Reduced Transparency behavior is preserved.

Fixes #22.

## Validation

- `git diff --check`
- `xcodebuild -project Calyx.xcodeproj -scheme Calyx -configuration Release -derivedDataPath /tmp/CalyxReleaseFixed -destination 'platform=macOS,arch=arm64' ONLY_ACTIVE_ARCH=YES build`\n- Installed and launched `/Applications/Calyx.app` locally from the Release arm64 build.