### PR TITLE
fix(ipc): stop merging adjacent lines when removing the Hermes managed block

### DIFF
--- a/Calyx/Features/IPC/HermesConfigManager.swift
+++ b/Calyx/Features/IPC/HermesConfigManager.swift
@@ -362,24 +362,36 @@ struct HermesConfigManager: Sendable {
         // Iterate by repeatedly searching for a fresh valid block, since each
         // removal invalidates previously-computed ranges.
         while let range = findValidManagedBlocks(in: working).first {
-            var lower = range.lowerBound
-            var upper = range.upperBound
-
-            // Eat one trailing newline if present.
-            if upper < working.endIndex, working[upper] == "\n" {
-                upper = working.index(after: upper)
-            }
-            // Eat one leading newline if present (so the deleted block doesn't
-            // leave behind a blank-line gap).
-            if lower > working.startIndex {
-                let prev = working.index(before: lower)
-                if working[prev] == "\n" {
-                    lower = prev
-                }
-            }
+            let (lower, upper) = eatOneAdjacentNewline(in: working, range: range)
             working.removeSubrange(lower..<upper)
         }
         return working
+    }
+
+    /// Removes the block spanned by `range` plus exactly ONE of its adjacent
+    /// newlines (preferring the trailing one), so the line before the block
+    /// and the line after it end up separated by exactly one newline instead
+    /// of zero (lines merging) or two (a stray blank line).
+    private static func eatOneAdjacentNewline(
+        in content: String,
+        range: Range<String.Index>
+    ) -> (Range<String.Index>.Bound, Range<String.Index>.Bound) {
+        var lower = range.lowerBound
+        var upper = range.upperBound
+
+        if upper < content.endIndex, content[upper] == "\n" {
+            // Eat the trailing newline — the separator between the block and
+            // whatever follows is preserved by the newline before the block.
+            upper = content.index(after: upper)
+        } else if lower > content.startIndex {
+            // No trailing newline to eat (block is at EOF): fall back to
+            // eating the leading one instead, so we still remove exactly one.
+            let prev = content.index(before: lower)
+            if content[prev] == "\n" {
+                lower = prev
+            }
+        }
+        return (lower, upper)
     }
 
     /// Self-heal helper used during enableIPC: removes ANY BEGIN line through
@@ -391,33 +403,16 @@ struct HermesConfigManager: Sendable {
             let searchAfterBegin = beginRange.upperBound..<working.endIndex
             let upperBound = firstMatch(of: endLineRegex, in: working, range: searchAfterBegin)?.upperBound
                 ?? working.endIndex
-            var lower = beginRange.lowerBound
-            var upper = upperBound
-            if upper < working.endIndex, working[upper] == "\n" {
-                upper = working.index(after: upper)
-            }
-            if lower > working.startIndex {
-                let prev = working.index(before: lower)
-                if working[prev] == "\n" {
-                    lower = prev
-                }
-            }
+            let (lower, upper) = eatOneAdjacentNewline(
+                in: working,
+                range: beginRange.lowerBound..<upperBound
+            )
             working.removeSubrange(lower..<upper)
         }
         // Self-heal also removes orphan END lines that have no matching BEGIN,
         // so a broken state does not leak into the freshly-written file.
         while let endRange = firstMatch(of: endLineRegex, in: working) {
-            var lower = endRange.lowerBound
-            var upper = endRange.upperBound
-            if upper < working.endIndex, working[upper] == "\n" {
-                upper = working.index(after: upper)
-            }
-            if lower > working.startIndex {
-                let prev = working.index(before: lower)
-                if working[prev] == "\n" {
-                    lower = prev
-                }
-            }
+            let (lower, upper) = eatOneAdjacentNewline(in: working, range: endRange)
             working.removeSubrange(lower..<upper)
         }
         return working

--- a/Calyx/Features/IPC/HermesConfigManager.swift
+++ b/Calyx/Features/IPC/HermesConfigManager.swift
@@ -362,7 +362,7 @@ struct HermesConfigManager: Sendable {
         // Iterate by repeatedly searching for a fresh valid block, since each
         // removal invalidates previously-computed ranges.
         while let range = findValidManagedBlocks(in: working).first {
-            let (lower, upper) = eatOneAdjacentNewline(in: working, range: range)
+            let (lower, upper) = removeAdjacentNewline(in: working, range: range)
             working.removeSubrange(lower..<upper)
         }
         return working
@@ -372,7 +372,7 @@ struct HermesConfigManager: Sendable {
     /// newlines (preferring the trailing one), so the line before the block
     /// and the line after it end up separated by exactly one newline instead
     /// of zero (lines merging) or two (a stray blank line).
-    private static func eatOneAdjacentNewline(
+    private static func removeAdjacentNewline(
         in content: String,
         range: Range<String.Index>
     ) -> (Range<String.Index>.Bound, Range<String.Index>.Bound) {
@@ -380,12 +380,12 @@ struct HermesConfigManager: Sendable {
         var upper = range.upperBound
 
         if upper < content.endIndex, content[upper] == "\n" {
-            // Eat the trailing newline — the separator between the block and
-            // whatever follows is preserved by the newline before the block.
+            // Remove the trailing newline — the separator between the block
+            // and whatever follows is preserved by the newline before the block.
             upper = content.index(after: upper)
         } else if lower > content.startIndex {
-            // No trailing newline to eat (block is at EOF): fall back to
-            // eating the leading one instead, so we still remove exactly one.
+            // No trailing newline to remove (block is at EOF): fall back to
+            // removing the leading one instead, so we still remove exactly one.
             let prev = content.index(before: lower)
             if content[prev] == "\n" {
                 lower = prev
@@ -403,7 +403,7 @@ struct HermesConfigManager: Sendable {
             let searchAfterBegin = beginRange.upperBound..<working.endIndex
             let upperBound = firstMatch(of: endLineRegex, in: working, range: searchAfterBegin)?.upperBound
                 ?? working.endIndex
-            let (lower, upper) = eatOneAdjacentNewline(
+            let (lower, upper) = removeAdjacentNewline(
                 in: working,
                 range: beginRange.lowerBound..<upperBound
             )
@@ -412,7 +412,7 @@ struct HermesConfigManager: Sendable {
         // Self-heal also removes orphan END lines that have no matching BEGIN,
         // so a broken state does not leak into the freshly-written file.
         while let endRange = firstMatch(of: endLineRegex, in: working) {
-            let (lower, upper) = eatOneAdjacentNewline(in: working, range: endRange)
+            let (lower, upper) = removeAdjacentNewline(in: working, range: endRange)
             working.removeSubrange(lower..<upper)
         }
         return working

--- a/CalyxTests/IPC/HermesConfigManagerTests.swift
+++ b/CalyxTests/IPC/HermesConfigManagerTests.swift
@@ -267,7 +267,7 @@ final class HermesConfigManagerTests: XCTestCase {
     /// (e.g. `toolsets:`) is the exact shape that corrupted a real user's
     /// config. Re-enabling calls the self-heal path (`stripAllManagedRegions`)
     /// to remove the previously-inserted block before writing a fresh one;
-    /// that removal must not eat the newline separating the block from the
+    /// that removal must not remove the newline separating the block from the
     /// following top-level key, or the two lines merge into invalid YAML.
     func test_enableIPC_idempotentInsert_preservesFollowingTopLevelKey() throws {
         // Given: mcp_servers: with a child, followed by a sibling top-level key.

--- a/CalyxTests/IPC/HermesConfigManagerTests.swift
+++ b/CalyxTests/IPC/HermesConfigManagerTests.swift
@@ -263,6 +263,40 @@ final class HermesConfigManagerTests: XCTestCase {
                        "Old token should be gone")
     }
 
+    /// Regression test: mcp_servers: followed by a sibling top-level key
+    /// (e.g. `toolsets:`) is the exact shape that corrupted a real user's
+    /// config. Re-enabling calls the self-heal path (`stripAllManagedRegions`)
+    /// to remove the previously-inserted block before writing a fresh one;
+    /// that removal must not eat the newline separating the block from the
+    /// following top-level key, or the two lines merge into invalid YAML.
+    func test_enableIPC_idempotentInsert_preservesFollowingTopLevelKey() throws {
+        // Given: mcp_servers: with a child, followed by a sibling top-level key.
+        let existing = """
+        mcp_servers:
+          stripe:
+            url: "https://mcp.stripe.com"
+        toolsets:
+          - hermes-cli
+          - web
+        """
+        try writeConfig(existing)
+
+        // When: enableIPC is called twice (second call exercises the
+        // self-heal removal of the first call's block).
+        try HermesConfigManager.enableIPC(port: 41830, token: "first-tok", configPath: configPath)
+        try HermesConfigManager.enableIPC(port: 55555, token: "second-tok", configPath: configPath)
+
+        // Then: the following top-level key must remain on its own line,
+        // not merged onto the end of a preceding value.
+        let content = readConfig()
+        XCTAssertTrue(content.contains("\ntoolsets:\n"),
+                      "toolsets: must remain on its own line, not merged with adjacent content")
+        XCTAssertTrue(content.contains("  - hermes-cli"),
+                      "Content after the managed block should be preserved intact")
+        XCTAssertTrue(content.contains("  - web"),
+                      "Content after the managed block should be preserved intact")
+    }
+
     // MARK: - enableIPC: Unsupported YAML structure
 
     func test_enableIPC_throwsOnInlineMcpServersMap() throws {
@@ -563,6 +597,40 @@ final class HermesConfigManagerTests: XCTestCase {
                        "END marker (managed) should be removed")
         XCTAssertFalse(content.contains("calyx-ipc:"),
                        "calyx-ipc child should be removed")
+    }
+
+    /// Regression test: mcp_servers: followed by a sibling top-level key
+    /// (e.g. `toolsets:`) is the exact shape that corrupted a real user's
+    /// config. Removing the managed block must leave exactly one newline
+    /// between the preserved content before the block and the top-level
+    /// key after it — not zero (lines merge into invalid YAML) or two (a
+    /// stray blank line).
+    func test_disableIPC_preservesFollowingTopLevelKey() throws {
+        // Given: Case B setup where mcp_servers: is followed by another
+        // top-level key with no blank line in between.
+        let existing = """
+        mcp_servers:
+          stripe:
+            url: "https://mcp.stripe.com"
+        toolsets:
+          - web
+        """
+        try writeConfig(existing)
+        try HermesConfigManager.enableIPC(port: 41830, token: "tok", configPath: configPath)
+        XCTAssertTrue(readConfig().contains("calyx-ipc:"),
+                      "Test setup: enable should have inserted the managed sub-block")
+
+        // When
+        try HermesConfigManager.disableIPC(configPath: configPath)
+
+        // Then
+        let content = readConfig()
+        XCTAssertFalse(content.contains("stripe.com\"toolsets:"),
+                       "Removing the managed block must not merge the surrounding lines")
+        XCTAssertTrue(content.contains("url: \"https://mcp.stripe.com\"\ntoolsets:"),
+                      "Exactly one newline should separate preserved content from the following key")
+        XCTAssertTrue(content.contains("  - web"),
+                      "Content after the managed block should be preserved intact")
     }
 
     func test_disableIPC_removesEmptyMcpServersWhenOnlyChild() throws {


### PR DESCRIPTION
## TLDR

Calyx breaks my Hermes Agent config whenever I enable Calyx IPC

## What changed

`stripValidManagedBlocks` and `stripAllManagedRegions` in `HermesConfigManager.swift` each removed one newline before `BEGIN` *and* one newline after `END` when stripping the managed IPC block. When the block sits directly between two content lines (no blank-line padding — the normal Case B shape), that deletes both separating newlines instead of the single one needed, splicing the surrounding lines together.

Extracted the shared logic into `eatOneAdjacentNewline`, which removes exactly one adjacent newline (preferring the trailing one, falling back to the leading one only at EOF where there's no trailing newline to eat).

## Why it changed

Traced a real corrupted `~/.hermes/config.yaml`: the file had `mcp_servers:` followed by a sibling top-level `toolsets:` key. Disabling and re-enabling Calyx IPC merged the last `mcp_servers` child's line directly into `toolsets:` (e.g. `Authorization: "Bearer ...token"toolsets:`), which is invalid YAML. That broke hermes's config parser outright, and the corruption also confused `insertCaseB`'s indent-based scan on the next `enableIPC` call (it walked past the now-merged `toolsets:` line looking for the true end of `mcp_servers:`, inserting the fresh block in the wrong place).

None of the existing tests covered a managed block followed by a sibling top-level key with no blank-line padding — every Case B test either had the block at EOF or nothing following it, so the missing-newline bug had no coverage.

## How to test

Added two regression tests reproducing the exact shape that broke:
- `test_disableIPC_preservesFollowingTopLevelKey` — enable then disable with `mcp_servers:` followed immediately by `toolsets:`; asserts exactly one newline separates the preserved content from the following key.
- `test_enableIPC_idempotentInsert_preservesFollowingTopLevelKey` — same shape, calling `enableIPC` twice (exercises the self-heal removal path).

I don't have a full Xcode install in the environment I worked in (CLI Tools only, and the project uses XcodeGen with no checked-in `.xcodeproj`), so I could not run `xcodebuild test` myself. I did verify the newline-eating logic manually and reproduced the exact corruption with an isolated Python simulation of the original code before writing the fix. Please run the `HermesConfigManagerTests` suite before merging.