### PR TITLE
Wire up prompt_tab_title/prompt_surface_title keybinds

### DIFF
--- a/Calyx/GhosttyBridge/GhosttyAction.swift
+++ b/Calyx/GhosttyBridge/GhosttyAction.swift
@@ -150,6 +150,9 @@ enum GhosttyActionRouter {
         case GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL:
             return handleToggleQuickTerminal(app, target: target)
 
+        case GHOSTTY_ACTION_PROMPT_TITLE:
+            return handlePromptTitle(app, target: target, value: action.action.prompt_title)
+
         case GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
              GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW,
              GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
@@ -160,7 +163,6 @@ enum GhosttyActionRouter {
              GHOSTTY_ACTION_PRESENT_TERMINAL,
              GHOSTTY_ACTION_QUIT_TIMER,
              GHOSTTY_ACTION_FLOAT_WINDOW,
-             GHOSTTY_ACTION_PROMPT_TITLE,
              GHOSTTY_ACTION_INSPECTOR,
              GHOSTTY_ACTION_RENDER_INSPECTOR,
              GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
@@ -194,6 +196,27 @@ enum GhosttyActionRouter {
             name: .ghosttySetTitle,
             object: surfaceView,
             userInfo: ["title": title]
+        )
+        return true
+    }
+
+    /// Fired by the `prompt_surface_title`/`prompt_tab_title` keybind
+    /// actions (always dispatched with a surface target — see
+    /// `Surface.zig`'s `prompt_surface_title`/`prompt_tab_title` cases).
+    /// Calyx has no per-pane title distinct from the tab (no split-pane
+    /// header UI), so both variants forward the same way, as
+    /// `.ghosttyPromptTabTitle`, for `CalyxWindowController` to show the
+    /// rename prompt for the tab that owns this surface.
+    private static func handlePromptTitle(
+        _ app: ghostty_app_t,
+        target: ghostty_target_s,
+        value: ghostty_action_prompt_title_e
+    ) -> Bool {
+        guard let surfaceView = surfaceView(from: target) else { return false }
+
+        NotificationCenter.default.post(
+            name: .ghosttyPromptTabTitle,
+            object: surfaceView
         )
         return true
     }

--- a/Calyx/GhosttyBridge/GhosttyApp.swift
+++ b/Calyx/GhosttyBridge/GhosttyApp.swift
@@ -502,6 +502,7 @@ extension Notification.Name {
     static let ghosttyCloseTab = Notification.Name("com.calyx.ghostty.closeTab")
     static let ghosttyCloseWindow = Notification.Name("com.calyx.ghostty.closeWindow")
     static let ghosttySetTitle = Notification.Name("com.calyx.ghostty.setTitle")
+    static let ghosttyPromptTabTitle = Notification.Name("com.calyx.ghostty.promptTabTitle")
     static let ghosttySetPwd = Notification.Name("com.calyx.ghostty.setPwd")
     static let ghosttyCellSizeChange = Notification.Name("com.calyx.ghostty.cellSizeChange")
     static let ghosttyInitialSize = Notification.Name("com.calyx.ghostty.initialSize")

--- a/Calyx/Models/Session/Tab.swift
+++ b/Calyx/Models/Session/Tab.swift
@@ -21,6 +21,13 @@ class Tab: Identifiable {
     var content: TabContent
     var unreadNotifications: Int = 0
     var lastNotificationTime: Date?
+    /// Bumped to request that whichever tab UI (`TabItemButton` or
+    /// `TabRowItemView`) is currently displaying this tab enter inline
+    /// rename mode, mirroring what a double-click does. Set by the
+    /// `prompt_tab_title`/`prompt_surface_title` keybind handler in
+    /// `CalyxWindowController`, since that fires from AppKit with no
+    /// direct handle on the SwiftUI view's local `isEditing` state.
+    var renameRequestID: UUID?
     let registry: SurfaceRegistry
     /// calyx-session references for this tab's persistent-session
     /// leaves, keyed by leaf (surface) UUID. Empty for a tab with no

--- a/Calyx/Views/MainWindow/CalyxWindowController.swift
+++ b/Calyx/Views/MainWindow/CalyxWindowController.swift
@@ -2072,6 +2072,8 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
                            name: .ghosttyEqualizeSplits, object: nil)
         center.addObserver(self, selector: #selector(handleSetTitleNotification(_:)),
                            name: .ghosttySetTitle, object: nil)
+        center.addObserver(self, selector: #selector(handlePromptTabTitleNotification(_:)),
+                           name: .ghosttyPromptTabTitle, object: nil)
         center.addObserver(self, selector: #selector(handleSetPwdNotification(_:)),
                            name: .ghosttySetPwd, object: nil)
         center.addObserver(self, selector: #selector(handleProgressReportNotification(_:)),
@@ -3060,6 +3062,25 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
             window?.title = tab.titleOverride ?? title
             refreshHostingView()
         }
+    }
+
+    /// `prompt_surface_title`/`prompt_tab_title` keybind, forwarded from
+    /// `GhosttyActionRouter.handlePromptTitle` as `.ghosttyPromptTabTitle`.
+    @objc private func handlePromptTabTitleNotification(_ notification: Notification) {
+        guard let surfaceView = notification.object as? SurfaceView else { return }
+        guard belongsToThisWindow(surfaceView) else { return }
+        guard let (tab, _) = findTab(for: surfaceView) else { return }
+
+        promptTabTitle(for: tab)
+    }
+
+    /// Triggers the same inline rename editor a double-click on `tab`
+    /// opens, by bumping `Tab.renameRequestID` — `TabItemButton`
+    /// (`TabBarContentView`) and `TabRowItemView` (`SidebarContentView`)
+    /// both observe it and flip their local `isEditing` state, so this
+    /// works whichever of the two is currently displaying the tab.
+    private func promptTabTitle(for tab: Tab) {
+        tab.renameRequestID = UUID()
     }
 
     /// OSC 9;4 progress-report signal (`GHOSTTY_ACTION_PROGRESS_REPORT`,

--- a/Calyx/Views/Sidebar/SidebarContentView.swift
+++ b/Calyx/Views/Sidebar/SidebarContentView.swift
@@ -647,6 +647,9 @@ private struct TabRowItemView: View {
             ))
         }
         .onAssumeInsideHover($isHovering)
+        .onChange(of: tab.renameRequestID) { _, newValue in
+            if newValue != nil { isEditing = true }
+        }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.Sidebar.tab(tab.id))
         // The title `Text` lives inside the `TabClickContainer`'s

--- a/Calyx/Views/TabBar/TabBarContentView.swift
+++ b/Calyx/Views/TabBar/TabBarContentView.swift
@@ -458,6 +458,9 @@ private struct TabItemButton: View {
             ))
         }
         .onHover { isHovering = $0 }
+        .onChange(of: tab.renameRequestID) { _, newValue in
+            if newValue != nil { isEditing = true }
+        }
         // The tab body is hosted inside an `NSHostingView` (via
         // `TabClickContainer`), whose AppKit subtree owns the
         // accessibility children. Without an explicit container element a


### PR DESCRIPTION
A feature I enjoy in Ghostty that isn't supported by Calyx is the ability to change tab titles through a keyboard shortcut. It would be really nice to have that feature. This is a possible implementation. I admittedly leaned into AI to help me write it, so there may be a better way to do it.

## Summary
- `GhosttyActionRouter` previously dropped `GHOSTTY_ACTION_PROMPT_TITLE`; it now forwards the surface's owning tab to `CalyxWindowController` via a new `.ghosttyPromptTabTitle` notification.
- The keybind (`prompt_tab_title`/`prompt_surface_title`) triggers the tab's existing inline rename editor — the same one double-click opens — rather than a separate dialog, so both entry points write to `Tab.titleOverride` identically and stay visually consistent.
- Added `Tab.renameRequestID`, an observable trigger `TabItemButton` (tab bar) and `TabRowItemView` (sidebar) both watch to flip into their local `isEditing` state, since the keybind fires from AppKit with no direct handle on that SwiftUI-local state.

## Test plan
- [x] `xcodebuild -project Calyx.xcodeproj -scheme Calyx -configuration Debug build` succeeds
- [x] Manually verified: bound `prompt_tab_title` to `super+shift+t` in `~/.config/ghostty/config`, confirmed it opens the tab bar's inline editor with the current title pre-selected, typing + Enter renames and persists across restart