### PR TITLE
Fix tab_create cwd override being dropped when persistent sessions are off

### DIFF
--- a/Calyx/Views/MainWindow/CalyxWindowController.swift
+++ b/Calyx/Views/MainWindow/CalyxWindowController.swift
@@ -1261,10 +1261,15 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
     /// parameter existed. Reached by `AppDelegate.spawnRemoteSessionTab
     /// (host:)` when a key window controller already exists.
     ///
-    /// `spawnCwd` (Cockpit `tab_create`): forwarded to
+    /// `spawnCwd` (Cockpit `tab_create`): resolved via
     /// `resolveNewTabSpawnCwd(override:)`, which returns the pre-Cockpit
     /// `activeTab?.pwd ?? NSHomeDirectory()` expression unchanged when
-    /// `nil` (every existing caller's shape).
+    /// `nil` (every existing caller's shape). The resolved value is passed
+    /// as BOTH `passthroughPwd` and `spawnCwd` into `createManagedSurface`
+    /// -- `createManagedSurface`'s `.passthrough` branch (the default;
+    /// persistent sessions are opt-in) only reads `passthroughPwd`, so a
+    /// `tab_create` cwd override that fed `spawnCwd` alone was silently
+    /// dropped whenever persistent sessions were off.
     func createNewTab(inheritedConfig: Any? = nil, host: String? = nil, spawnCwd: String? = nil) {
         guard let app = GhosttyAppController.shared.app,
               let window = self.window,
@@ -1280,9 +1285,10 @@ class CalyxWindowController: NSWindowController, NSWindowDelegate {
         }
         config.scale_factor = Double(window.backingScaleFactor)
 
+        let resolvedSpawnCwd = resolveNewTabSpawnCwd(override: spawnCwd)
         guard let surfaceID = createManagedSurface(
             tab: tab, app: app, config: config,
-            passthroughPwd: nil, spawnCwd: resolveNewTabSpawnCwd(override: spawnCwd), origin: .tab, host: host
+            passthroughPwd: resolvedSpawnCwd, spawnCwd: resolvedSpawnCwd, origin: .tab, host: host
         ) else {
             logger.error("Failed to create surface for new tab")
             return


### PR DESCRIPTION
It would be useful if my agents could open a tab in a particular directory. It seemed like the functionality was there, but it wasn't working in practice. This is a suggested fix.

## Summary
- `createNewTab` resolved the Cockpit `tab_create` `cwd` override via `resolveNewTabSpawnCwd`, but only passed it into `createManagedSurface`'s `spawnCwd` parameter while hardcoding `passthroughPwd: nil`.
- `createManagedSurface`'s `.passthrough` branch (the default, since persistent sessions are opt-in) reads `passthroughPwd`, not `spawnCwd` — so a `tab_create` cwd override was silently dropped whenever persistent sessions were off, and the new tab spawned with no explicit working directory instead of the requested one.
- Fix: resolve the spawn cwd once and pass that same value as both `passthroughPwd` and `spawnCwd`, so the override reaches whichever branch is active.

## Testing
- `xcodegen generate` + `xcodebuild test` — ran `CalyxWindowControllerCreateManagedSurfaceRemoteHostTests` and `CockpitAppAccessSeamTests` (the existing tests closest to this code path): 9/9 passed, no regressions.
- Built and launched the fixed app locally; confirmed `tab_create` with a `cwd` argument now opens the new tab in the requested directory instead of falling back to the wrong one.
- No new regression test added: `createNewTab` guards on `GhosttyAppController.shared.app`, which is `nil` in the test host, so it can't be driven end-to-end in a unit test — an existing, already-documented constraint (see `CockpitAppAccessSeamTests.swift`'s header, which is why it only tests the extracted `resolveNewTabSpawnCwd` helper in isolation rather than this call-site wiring).